### PR TITLE
Bugfix Organisationslinks

### DIFF
--- a/site/views/einsatzbericht/tmpl/detail_layout_1.php
+++ b/site/views/einsatzbericht/tmpl/detail_layout_1.php
@@ -191,7 +191,7 @@ $lang->load('com_einsatzkomponente', JPATH_ADMINISTRATOR);
 					$db->setQuery($query);
 					$results = $db->loadObjectList();
 					if ($results[0]->name) :
-					if ($this->params->get('display_detail_orga_links','1')) :
+					if ($this->params->get('display_orga_links','1')) :
 					if (!$results[0]->link) :
 					?>
 					<a target="_self" href="<?php echo JRoute::_('index.php?option=com_einsatzkomponente&view=organisation&id=' . $results[0]->id); ?>"><?php echo $results[0]->name; ?></a><br/>
@@ -229,7 +229,7 @@ $lang->load('com_einsatzkomponente', JPATH_ADMINISTRATOR);
 						if ($value->state == '2'): $value->name = $value->name.' (a.D.)';endif;
 						echo '<li>';
 						//if ($array_vehicle == $value->id) : echo $value->name;break; endif;
-						if ($this->params->get('display_detail_fhz_links','1')) :
+						if ($this->params->get('display_orga_fhz_links','1')) :
 						if (!$value->link) : ?>
                         
 						<a title ="<?php echo $value->detail2;?>" target="_self" href="<?php echo JRoute::_('index.php?option=com_einsatzkomponente&view=einsatzfahrzeug&id=' . $value->id); ?>"><?php echo $value->name; ?></a>

--- a/site/views/organisation/view.html.php
+++ b/site/views/organisation/view.html.php
@@ -36,7 +36,7 @@ class EinsatzkomponenteViewOrganisation extends JViewLegacy {
    		$this->form		= $this->get('Form');
 		$this->gmap_config = EinsatzkomponenteHelper::load_gmap_config(); // GMap-Config aus helper laden 
         //print_r ($this->item);break;
-		$this->orga_fahrzeuge = EinsatzkomponenteHelper::getOrga_fahrzeuge($this->item->name);  
+		$this->orga_fahrzeuge = EinsatzkomponenteHelper::getOrga_fahrzeuge($this->item->id);  
 	    $document = JFactory::getDocument();
 
 		


### PR DESCRIPTION
Erster Bugfix: 

http://www.einsatzkomponente.de/wpbt/index.php/Issue/91-Organisationslinks-f%C3%BChren-ins-Leere/

Funktion war implementiert, Feldname war im Template jedoch falsch geschrieben.

In der config.xml im Pfad "administrator/components/com_einsatzkomponente" war ein anderer Parametername für die Option zum deaktiveren der Links angegeben als im Template. Ist hiermit korrigiert und auf Funktionalität getestet

---

Zweiter Bugfixt:

http://www.einsatzkomponente.de/wpbt/index.php/Issue/112-in-der-Organisation-die-Fahrzeug-anzeige-bleibt-leer/

Hier war noch von früher der Name der Organisation angegeben. Die neuen SQLs jedoch benötigen die ID. Ist hiermit korrigiert und getestet.
