### PR TITLE
entferne überflüssigen Slash vor $rep_id_ordner

### DIFF
--- a/administrator/controllers/einsatzbericht.php
+++ b/administrator/controllers/einsatzbericht.php
@@ -586,7 +586,7 @@ while($count < $count_data)
 		$db		= JFactory::getDBO();
 		$query	= $db->getQuery(true);
 		$query->update('#__eiko_einsatzberichte');
-		$query->set('image = "'.$custompath.'/'.$rep_id_ordner.'/'.$fileName.'" ');
+		$query->set('image = "'.$custompath.$rep_id_ordner.'/'.$fileName.'" ');
 		$query->where('`id` ="'.$rep_id.'"');
 		$db->setQuery((string) $query);
 


### PR DESCRIPTION
$rep_id_ordner wird mit führendem Slash definiert:
`$rep_id_ordner = '/'.$rep_id;`

An der geänderten Stelle wird davor noch ein Slash eingefügt: `$custompath.'/'.$rep_id_ordner`
Dadurch kommen Pfade raus wie z.B `images/com_einsatzkompnente/einsatzberichte//1234/Img_321.jpg` - also mit Doppelslash // drinnen.

In den Zeilen darüber ist alles ok und ich habe die beanstandete Stelle daran angepasst.

Pull-Request zukünftig lieber gegen **master** oder **beta** erstelllen?
