### PR TITLE
Einsatzübersicht: Prüfe Monat und Jahr für die Anzeige des Monatsnamens

### DIFF
--- a/site/views/einsatzarchiv/tmpl/main_layout_1.php
+++ b/site/views/einsatzarchiv/tmpl/main_layout_1.php
@@ -134,6 +134,7 @@ defined('_JEXEC') or die;
            <?php if ($item->date1_year != $y&& $this->params->get('display_home_jahr','1')) : ?>
 		   <tr class="eiko_einsatzarchiv_jahr_tr"><td class="eiko_einsatzarchiv_jahr_td" colspan="<?php echo $eiko_col; ?>">
            <?php $y= $item->date1_year;?>
+           <?php $m= ''; /* reset month for new year */ ?>
 		   <?php echo '<div class="eiko_einsatzarchiv_jahr_div">';?>
            <?php echo 'Einsatzberichte '. $item->date1_year.'';?> 
            <?php echo '</div>';?>
@@ -142,7 +143,7 @@ defined('_JEXEC') or die;
            <!--Anzeige des Jahres ENDE-->
 
            <!--Anzeige des Monatsnamen-->
-           <?php if ($item->date1_month != $m && $this->params->get('display_home_monat','1')) : ?>
+           <?php if (($item->date1_month != $m || $item->date1_year != $y) && $this->params->get('display_home_monat','1')) : ?>
 		   <tr class="eiko_einsatzarchiv_monat_tr"><td class="eiko_einsatzarchiv_monat_td" colspan="<?php echo $eiko_col; ?>">
            <?php $m= $item->date1_month;?>
 		   <?php echo '<div class="eiko_einsatzarchiv_monat_div">';?>

--- a/site/views/einsatzarchiv/tmpl/main_layout_2.php
+++ b/site/views/einsatzarchiv/tmpl/main_layout_2.php
@@ -120,6 +120,7 @@ defined('_JEXEC') or die;
            <?php if ($item->date1_year != $y&& $this->params->get('display_home_jahr','1')) : ?>
 		   <tr class="eiko_einsatzarchiv_jahr_tr"><td class="eiko_einsatzarchiv_jahr_td" colspan="<?php echo $eiko_col; ?>">
            <?php $y= $item->date1_year;?>
+           <?php $m= ''; /* reset month for new year */ ?>
 		   <?php echo '<div class="eiko_einsatzarchiv_jahr_div">';?>
            <?php echo 'Einsatzberichte '. $item->date1_year.'';?> 
            <?php echo '</div>';?>
@@ -128,7 +129,7 @@ defined('_JEXEC') or die;
            <!--Anzeige des Jahres ENDE-->
 
            <!--Anzeige des Monatsnamen-->
-           <?php if ($item->date1_month != $m && $this->params->get('display_home_monat','1')) : ?>
+           <?php if (($item->date1_month != $m || $item->date1_year != $y) && $this->params->get('display_home_monat','1')) : ?>
 		   <tr class="eiko_einsatzarchiv_monat_tr"><td class="eiko_einsatzarchiv_monat_td" colspan="<?php echo $eiko_col; ?>">
            <?php $m= $item->date1_month;?>
 		   <?php echo '<div class="eiko_einsatzarchiv_monat_div">';?>

--- a/site/views/einsatzarchiv/tmpl/main_layout_3.php
+++ b/site/views/einsatzarchiv/tmpl/main_layout_3.php
@@ -83,6 +83,7 @@ defined('_JEXEC') or die;
            <?php if ($item->date1_year != $y && $this->params->get('display_home_jahr','1')) : ?>
 		   <tr class="eiko_einsatzarchiv_jahr_tr"><td class="eiko_einsatzarchiv_jahr_td" colspan="<?php echo $eiko_col;?>">
            <?php $y= $item->date1_year;?>
+           <?php $m= ''; /* reset month for new year */ ?>
 		   <?php echo '<div class="eiko_einsatzarchiv_jahr_div">';?>
            <?php echo JText::_('COM_EINSATZKOMPONENTE_TITLE_MAIN_3').' '. $item->date1_year.''; ?>  
            <?php echo '</div>';?>
@@ -91,7 +92,7 @@ defined('_JEXEC') or die;
            <!--Anzeige des Jahres ENDE-->
 
            <!--Anzeige des Monatsnamen-->
-           <?php if ($item->date1_month != $m && $this->params->get('display_home_monat','1')) : ?>
+           <?php if (($item->date1_month != $m || $item->date1_year != $y) && $this->params->get('display_home_monat','1')) : ?>
 		   <tr class="eiko_einsatzarchiv_monat_tr"><td class="eiko_einsatzarchiv_monat_td" colspan="<?php echo $eiko_col;?>">
            <?php $m= $item->date1_month;?>
 		   <?php echo '<div class="eiko_einsatzarchiv_monat_div">';?>


### PR DESCRIPTION
Wenn zwei Einsätze aufeinander folgen, die beide im selben Monat aber in unterschiedlichen Jahren liegen, wurde der Monatsnamen nicht noch mal gezeigt, weil nur auf den Monat, nicht aber das Jahr geprüft wurde.

Bsp:
vorher
```
Januar 2017
1.1.2017 Einsatz A
2.1.2016 Einsatz B
1.1.2016 Einsatz C
...
```
jetzt
```
Januar 2017
1.1.2017 Einsatz A
Januar 2016
2.1.2016 Einsatz B
1.1.2016 Einsatz C
...
```