### PR TITLE
Einsatzarchiv: diverse Patches

### DIFF
--- a/administrator/config.xml
+++ b/administrator/config.xml
@@ -1855,7 +1855,7 @@
 		<field 	name="main_css" 
 				type="textarea" 
 				filter="raw" 
-				default=".eiko_td_marker_main_1 {color:#ffffff;} .eiko_einsatzarchiv_jahr_tr,eiko_einsatzarchiv_jahr_td{background-color:#dddddd;color:#000000;font-size:24px !important;font-weight:bold !important;margin-top:50px !important;} eiko_einsatzarchiv_jahr_div {color:#ffffff important;} .eiko_einsatzarchiv_monat_tr,eiko_einsatzarchiv_monat_td {background-color:#cccccc;color:#000000;}eiko_einsatzarchiv_monat_div {color:#ffffff !important;}.eiko_span_marker_main_1 {color:#ffffff!important;}" 
+				default=""
 				label="COM_EINSATZKOMPONENTE_OPTION_CUSTOM_EINSATZ_UEBERSICHT" 
 				description="Füge hier den zusätzlichen CSS-Code für die Einsatz-Übersicht ein." 
 				rows="10" 

--- a/site/assets/css/einsatzkomponente.css
+++ b/site/assets/css/einsatzkomponente.css
@@ -697,6 +697,10 @@ padding-right:5px;
 .eiko_nowrap {white-space: nowrap;}
 .eiko_data1 {font-size:24px;}
 
+.eiko_einsatzarchiv_jahr_tr {background-color:#dddddd;color:#000000;font-size:24px !important;font-weight:bold !important;margin-top:50px !important;}
+.eiko_einsatzarchiv_monat_tr {background-color:#cccccc;color:#000000;}eiko_einsatzarchiv_monat_div {color:#ffffff !important;}
+.eiko_span_marker_main_1 {color:#ffffff!important;}
+
 .eiko_distance_road {font-size:smaller;padding-bottom:2em;}
 
 .eiko_ausruestung {margin-top: 10px;}
@@ -714,4 +718,3 @@ padding-right:5px;
 .icon-next::before, .icon-forward::before {
     content: "" !important;
 }
-

--- a/site/views/einsatzarchiv/tmpl/main_layout_1.php
+++ b/site/views/einsatzarchiv/tmpl/main_layout_1.php
@@ -162,33 +162,30 @@ defined('_JEXEC') or die;
 			<?php echo '<span style="white-space: nowrap;" class="eiko_span_marker_main_1">Nr. '.EinsatzkomponenteHelper::ermittle_einsatz_nummer($item->date1,$item->data1_id).'</span>';?> 
 			</td>
            <?php endif;?>
-		   
-		   
-           <?php if ($this->params->get('display_home_date_image','1')=='1') : ?>
-		   <td class="eiko_td_kalender_main_1"> 
-			<div class="home_cal_icon">
-			<div class="home_cal_monat"><?php echo date('M', $item->date1);?></div>
-			<div class="home_cal_tag"><?php echo date('d', $item->date1);?></div>
-			<div class="home_cal_jahr"><span style="font-size:10px;"><?php echo date('Y', $item->date1);?></span></div>
-			</div>
-           </td>
-           <?php endif;?>
-           <?php if ($this->params->get('display_home_date_image','1')=='2') : ?>
-		   <td class="eiko_td_datum_main_1"> <?php echo '<i class="icon-calendar" ></i> '.date('d.m.Y ', $item->date1);?><br /><?php echo '<i class="icon-clock" ></i> '.date('H:i ', $item->date1); ?>Uhr</td>
-           <?php endif;?>
-           <?php if ($this->params->get('display_home_date_image','1')=='0') : ?>
-		   <td class="eiko_td_datum_main_1"> <?php echo '<i class="icon-calendar" ></i> '.date('d.m.Y ', $item->date1);?></td>
-           <?php endif;?>
-           <?php if ($this->params->get('display_home_date_image','1')=='3') : ?>
-		   <td class="eiko_td_kalender_main_1"> 
-			<div class="home_cal_icon">
-			<div class="home_cal_monat"><?php echo date('M', $item->date1);?></div>
-			<div class="home_cal_tag"><?php echo date('d', $item->date1);?></div>
-			<div class="home_cal_jahr"><span style="font-size:10px;"><?php echo date('Y', $item->date1);?></span></div>
-			 <?php echo '<div style="font-size:12px;white-space: nowrap;">'.date('H:i ', $item->date1).' Uhr</div>'; ?>
-			</div>
-           </td>
-           <?php endif;?>
+
+
+           <?php $date_image = $this->params->get('display_home_date_image','1') ?>
+           <?php if ($date_image == '0' || $date_image == '2') : ?>
+             <td class="eiko_td_datum_main_1">
+               <i class="icon-calendar"></i> <?php echo date('d.m.Y', $item->date1); ?>
+               <?php if ($date_image == '2') : ?>
+                 <br /><i class="icon-clock"></i> <?php echo date('H:i', $item->date1); ?>Uhr
+               <?php endif; ?>
+             </td>
+           <?php endif; ?>
+
+           <?php if ($date_image == '1' || $date_image == '3') : ?>
+             <td class="eiko_td_kalender_main_1">
+               <div class="home_cal_icon">
+                 <div class="home_cal_monat"><?php echo date('M', $item->date1); ?></div>
+                 <div class="home_cal_tag"><?php echo date('d', $item->date1); ?></div>
+                 <div class="home_cal_jahr"><span style="font-size:10px;"><?php echo date('Y', $item->date1); ?></span></div>
+                 <?php if ($date_image == '3') : ?>
+                   <div style="font-size: 12px; white-space: nowrap;"><?php echo date('H:i', $item->date1); ?>Uhr</div>
+                 <?php endif; ?>
+               </div>
+             </td>
+           <?php endif; ?>
 
             	<td>
 					<?php if (isset($item->checked_out) && $item->checked_out) : ?>

--- a/site/views/einsatzarchiv/tmpl/main_layout_1.php
+++ b/site/views/einsatzarchiv/tmpl/main_layout_1.php
@@ -145,6 +145,7 @@ defined('_JEXEC') or die;
 
            <!--Anzeige des Monatsnamen-->
            <?php if (($item->date1_month != $m || $item->date1_year != $y) && $this->params->get('display_home_monat','1')) : ?>
+           <?php $y = $item->date1_year; // $y may not have been set before if display_home_jahr is 0 ?>
 		   <tr class="eiko_einsatzarchiv_monat_tr"><td class="eiko_einsatzarchiv_monat_td" colspan="<?php echo $eiko_col; ?>">
            <?php $m= $item->date1_month;?>
 		   <?php echo '<div class="eiko_einsatzarchiv_monat_div">';?>

--- a/site/views/einsatzarchiv/tmpl/main_layout_2.php
+++ b/site/views/einsatzarchiv/tmpl/main_layout_2.php
@@ -130,6 +130,7 @@ defined('_JEXEC') or die;
 
            <!--Anzeige des Monatsnamen-->
            <?php if (($item->date1_month != $m || $item->date1_year != $y) && $this->params->get('display_home_monat','1')) : ?>
+           <?php $y = $item->date1_year; // $y may not have been set before if display_home_jahr is 0 ?>
 		   <tr class="eiko_einsatzarchiv_monat_tr"><td class="eiko_einsatzarchiv_monat_td" colspan="<?php echo $eiko_col; ?>">
            <?php $m= $item->date1_month;?>
 		   <?php echo '<div class="eiko_einsatzarchiv_monat_div">';?>

--- a/site/views/einsatzarchiv/tmpl/main_layout_2.php
+++ b/site/views/einsatzarchiv/tmpl/main_layout_2.php
@@ -145,31 +145,29 @@ defined('_JEXEC') or die;
 			<td>
 			<?php //echo $item->number;?>
 			</td>
-           <?php if ($this->params->get('display_home_date_image','1')=='1') : ?>
-		   <td class="eiko_td_kalender_main_1"> 
-			<div class="home_cal_icon">
-			<div class="home_cal_monat"><?php echo date('M', $item->date1);?></div>
-			<div class="home_cal_tag"><?php echo date('d', $item->date1);?></div>
-			<div class="home_cal_jahr"><span style="font-size:10px;"><?php echo date('Y', $item->date1);?></span></div>
-			</div>
-           </td>
-           <?php endif;?>
-           <?php if ($this->params->get('display_home_date_image','1')=='2') : ?>
-		   <td class="eiko_td_datum_main_1"> <?php echo date('d.m.Y ', $item->date1);?><br /><?php echo date('H:i ', $item->date1); ?>Uhr</td>
-           <?php endif;?>
-           <?php if ($this->params->get('display_home_date_image','1')=='0') : ?>
-		   <td class="eiko_td_datum_main_1"> <?php echo date('d.m.Y ', $item->date1);?></td>
-           <?php endif;?>
-           <?php if ($this->params->get('display_home_date_image','1')=='3') : ?>
-		   <td class="eiko_td_kalender_main_1"> 
-			<div class="home_cal_icon">
-			<div class="home_cal_monat"><?php echo date('M', $item->date1);?></div>
-			<div class="home_cal_tag"><?php echo date('d', $item->date1);?></div>
-			<div class="home_cal_jahr"><span style="font-size:10px;"><?php echo date('Y', $item->date1);?></span></div>
-			 <?php echo '<div style="font-size:12px;white-space: nowrap;">'.date('H:i ', $item->date1).' Uhr</div>'; ?>
-			</div>
-           </td>
-           <?php endif;?>
+
+        <?php $date_image = $this->params->get('display_home_date_image','1') ?>
+        <?php if ($date_image == '0' || $date_image == '2') : ?>
+          <td class="eiko_td_datum_main_1">
+            <?php echo date('d.m.Y', $item->date1); ?>
+            <?php if ($date_image == '2') : ?>
+              <br /><?php echo date('H:i', $item->date1); ?>Uhr
+            <?php endif; ?>
+          </td>
+        <?php endif; ?>
+
+        <?php if ($date_image == '1' || $date_image == '3') : ?>
+          <td class="eiko_td_kalender_main_1">
+            <div class="home_cal_icon">
+              <div class="home_cal_monat"><?php echo date('M', $item->date1); ?></div>
+              <div class="home_cal_tag"><?php echo date('d', $item->date1); ?></div>
+              <div class="home_cal_jahr"><span style="font-size:10px;"><?php echo date('Y', $item->date1); ?></span></div>
+              <?php if ($date_image == '3') : ?>
+                <div style="font-size: 12px; white-space: nowrap;"><?php echo date('H:i', $item->date1); ?>Uhr</div>
+              <?php endif;?>
+            </div>
+          </td>
+        <?php endif;?>
 
             	<td>
 					<?php if (isset($item->checked_out) && $item->checked_out) : ?>

--- a/site/views/einsatzarchiv/tmpl/main_layout_3.php
+++ b/site/views/einsatzarchiv/tmpl/main_layout_3.php
@@ -94,6 +94,7 @@ defined('_JEXEC') or die;
 
            <!--Anzeige des Monatsnamen-->
            <?php if (($item->date1_month != $m || $item->date1_year != $y) && $this->params->get('display_home_monat','1')) : ?>
+           <?php $y = $item->date1_year; // $y may not have been set before if display_home_jahr is 0 ?>
 		   <tr class="eiko_einsatzarchiv_monat_tr"><td class="eiko_einsatzarchiv_monat_td" colspan="<?php echo $eiko_col;?>">
            <?php $m= $item->date1_month;?>
 		   <?php echo '<div class="eiko_einsatzarchiv_monat_div">';?>

--- a/site/views/einsatzarchiv/tmpl/main_layout_4.php
+++ b/site/views/einsatzarchiv/tmpl/main_layout_4.php
@@ -167,33 +167,30 @@ defined('_JEXEC') or die;
 			<?php echo '<span style="white-space: nowrap;" class="eiko_span_marker_main_1">Nr. '.EinsatzkomponenteHelper::ermittle_einsatz_nummer($item->date1,$item->data1_id).'</span>';?> 
 			</td>
            <?php endif;?>
-		   
-		   
-           <?php if ($this->params->get('display_home_date_image','1')=='1') : ?>
-		   <td class="eiko_td_kalender_main_1"> 
-			<div class="home_cal_icon">
-			<div class="home_cal_monat"><?php echo date('M', $item->date1);?></div>
-			<div class="home_cal_tag"><?php echo date('d', $item->date1);?></div>
-			<div class="home_cal_jahr"><span style="font-size:10px;"><?php echo date('Y', $item->date1);?></span></div>
-			</div>
-           </td>
-           <?php endif;?>
-           <?php if ($this->params->get('display_home_date_image','1')=='2') : ?>
-		   <td class="eiko_td_datum_main_1"> <?php echo '<i class="icon-calendar" ></i> '.date('d.m.Y ', $item->date1);?><br /><?php echo '<i class="icon-clock" ></i> '.date('H:i ', $item->date1); ?>Uhr</td>
-           <?php endif;?>
-           <?php if ($this->params->get('display_home_date_image','1')=='0') : ?>
-		   <td class="eiko_td_datum_main_1"> <?php echo '<i class="icon-calendar" ></i> '.date('d.m.Y ', $item->date1);?></td>
-           <?php endif;?>
-           <?php if ($this->params->get('display_home_date_image','1')=='3') : ?>
-		   <td class="eiko_td_kalender_main_1"> 
-			<div class="home_cal_icon">
-			<div class="home_cal_monat"><?php echo date('M', $item->date1);?></div>
-			<div class="home_cal_tag"><?php echo date('d', $item->date1);?></div>
-			<div class="home_cal_jahr"><span style="font-size:10px;"><?php echo date('Y', $item->date1);?></span></div>
-			 <?php echo '<div style="font-size:12px;white-space: nowrap;">'.date('H:i ', $item->date1).' Uhr</div>'; ?>
-			</div>
-           </td>
-           <?php endif;?>
+
+
+          <?php $date_image = $this->params->get('display_home_date_image','1') ?>
+          <?php if ($date_image == '0' || $date_image == '2') : ?>
+            <td class="eiko_td_datum_main_1">
+              <i class="icon-calendar"></i> <?php echo date('d.m.Y', $item->date1); ?>
+              <?php if ($date_image == '2') : ?>
+                <br /><i class="icon-clock"></i> <?php echo date('H:i', $item->date1); ?>Uhr
+              <?php endif; ?>
+            </td>
+          <?php endif; ?>
+
+          <?php if ($date_image == '1' || $date_image == '3') : ?>
+            <td class="eiko_td_kalender_main_1">
+              <div class="home_cal_icon">
+                <div class="home_cal_monat"><?php echo date('M', $item->date1); ?></div>
+                <div class="home_cal_tag"><?php echo date('d', $item->date1); ?></div>
+                <div class="home_cal_jahr"><span style="font-size:10px;"><?php echo date('Y', $item->date1); ?></span></div>
+                <?php if ($date_image == '3') : ?>
+                  <div style="font-size: 12px; white-space: nowrap;"><?php echo date('H:i', $item->date1); ?>Uhr</div>
+                <?php endif; ?>
+              </div>
+            </td>
+          <?php endif; ?>
 
             	<td>
 					<?php if (isset($item->checked_out) && $item->checked_out) : ?>

--- a/site/views/einsatzarchiv/tmpl/main_layout_4.php
+++ b/site/views/einsatzarchiv/tmpl/main_layout_4.php
@@ -140,6 +140,7 @@ defined('_JEXEC') or die;
            <?php if ($item->date1_year != $y&& $this->params->get('display_home_jahr','1')) : ?>
 		   <tr class="eiko_einsatzarchiv_jahr_tr"><td class="eiko_einsatzarchiv_jahr_td" colspan="<?php echo $eiko_col; ?>">
            <?php $y= $item->date1_year;?>
+           <?php $m= ''; /* reset month for new year */ ?>
 		   <?php echo '<div class="eiko_einsatzarchiv_jahr_div">';?>
            <?php echo 'Einsatzberichte '. $item->date1_year.'';?> 
            <?php echo '</div>';?>
@@ -148,7 +149,8 @@ defined('_JEXEC') or die;
            <!--Anzeige des Jahres ENDE-->
 
            <!--Anzeige des Monatsnamen-->
-           <?php if ($item->date1_month != $m && $this->params->get('display_home_monat','1')) : ?>
+           <?php if (($item->date1_month != $m || $item->date1_year != $y) && $this->params->get('display_home_monat','1')) : ?>
+           <?php $y = $item->date1_year; // $y may not have been set before if display_home_jahr is 0 ?>
 		   <tr class="eiko_einsatzarchiv_monat_tr"><td class="eiko_einsatzarchiv_monat_td" colspan="<?php echo $eiko_col; ?>">
            <?php $m= $item->date1_month;?>
 		   <?php echo '<div class="eiko_einsatzarchiv_monat_div">';?>


### PR DESCRIPTION
Ein paar Kleinigkeiten. Zu den einzelnen Commits:

1. Wenn man die Jahresanzeige deaktiviert, wird über jedem einzelnen Einsatz der Monatsname angezeigt, statt nur über dem ersten des jeweiligen Monats. Den Fehler habe ich eingeschleust, als ich den Check für das Jahr ergänzt habe und wird hiermit behoben.

2. Die If-Bedingungen ein bisschen umgestellt.

3. Default-CSS entfernt, weil das nur stört. Wird standardmäßig gesetzt und wenn man etwas im Template ändert, kommt das nicht bei User an, weil es dort mit den alten Default-Werten aus der Datenbank überschrieben wird.